### PR TITLE
Add auto authenticate & resend message when token is invalid

### DIFF
--- a/src/js/api.js
+++ b/src/js/api.js
@@ -147,10 +147,26 @@ class Api {
   }
 
   async sendConversationMessage(conversationId, message) {
-    return this.webService.post(
-      `conversations/${conversationId}/messages`,
-      message,
-    );
+    try {
+      await this.webService.post(
+        `conversations/${conversationId}/messages`,
+        message,
+      );
+    } catch ({ error, status }) {
+      // If token is invalid
+      if (status === 401) {
+        try {
+          // Try to authenticate anounymous & resend message
+          await this.authService.authorizeAnonymous();
+          await this.sendConversationMessage(conversationId, message);
+        } catch {
+          // Auto connexion & resend have fail
+          window.location.reload();
+        }
+      } else {
+        throw error;
+      }
+    }
   }
 
   async resetConversationMessages(conversationId) {

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -132,23 +132,23 @@ const getUsername = () => {
   return username;
 };
 
-const sendSandboxMessage = (body) => {
+const sendSandboxMessage = async (body) => {
   // console.log("send sandbox message", body);
   const message = { from: getUsername(), body };
   // WIP send message
   if (body === "#reset") {
-    app.api.resetSandbox(app.bot.id);
+    await app.api.resetSandbox(app.bot.id);
     return true;
   }
   if (app.bot && app.conversationId) {
-    app.api.sendSandboxMessage(app.bot.id, app.conversationId, message);
+    await app.api.sendSandboxMessage(app.bot.id, app.conversationId, message);
     return true;
   }
   // app.messenger.appendMessage(message);
   return false;
 };
 
-const sendMessage = (body) => {
+const sendMessage = async (body) => {
   // console.log("send message", body);
   if (opla.config.sandbox) {
     return sendSandboxMessage(body);
@@ -157,11 +157,11 @@ const sendMessage = (body) => {
   const message = { from: username, body };
   // WIP send message
   if (body === "#reset") {
-    app.api.resetConversationMessages(app.conversationId);
+    await app.api.resetConversationMessages(app.conversationId);
     return true;
   }
   if (app.conversationId) {
-    app.api.sendConversationMessage(app.conversationId, message);
+    await app.api.sendConversationMessage(app.conversationId, message);
     return true;
   }
   // app.messenger.appendMessage(message);

--- a/src/js/services/fetch.js
+++ b/src/js/services/fetch.js
@@ -27,11 +27,11 @@ const fetch = (url, data = null, method = null, headers = {}) => {
       xhr.setRequestHeader(key, h[key]);
     });
     xhr.onload = () => {
+      const res = JSON.parse(xhr.response);
       if (xhr.status >= 200 && xhr.status < 300) {
-        const res = JSON.parse(xhr.response);
         resolve({ data: res, status: xhr.status });
       } else {
-        reject(Error(xhr.statusText));
+        reject(res);
       }
     };
     xhr.onerror = () => reject(xhr.statusText);

--- a/src/js/services/webService.js
+++ b/src/js/services/webService.js
@@ -40,7 +40,7 @@ class WebService {
             }
           })
           .catch((error) => {
-            reject(error.message);
+            reject(error);
           });
       }
     });


### PR DESCRIPTION
# Description

Add auto authenticate & resend message when token is invalid.

## Type of change

- [X] Other (non-breaking change which doesn't match an issue, Non-code related, ...)

# How Has This Been Tested?

Yarn lint have been launched & many realized on local.

**Test Configuration**:
* Yarn/npm/nodejs version: v1.13.0/v5.6.0/v8.10.0
* OS version: macOS 10.14.3
* Chrome version: Google Chrome 72.0.3626.109 

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas